### PR TITLE
Update Fixnum usage to Integer

### DIFF
--- a/lib/formtastic/inputs/select_many_input.rb
+++ b/lib/formtastic/inputs/select_many_input.rb
@@ -23,7 +23,7 @@ module Formtastic
       def hidden_input
         template.content_tag( :div, class: 'values', 'data-name': input_html_options[:name] ) do
           values = object.send( input_name )
-          values = [values] if values.is_a? Fixnum
+          values = [values] if values.is_a? Integer
           values.each do |value|
             template.concat template.hidden_field_tag( input_html_options[:name], value, {id: nil} )
           end if values
@@ -59,7 +59,7 @@ module Formtastic
         else
           # TODO: add option unique ?
           selected = object.send( input_name )
-          selected = [selected] if selected.is_a? Fixnum
+          selected = [selected] if selected.is_a? Integer
           selected ? collection.select { |option| !selected.include?( option[1] ) } : collection
         end
         opts = input_options.merge( name: nil, id: nil, multiple: true, 'data-select': 'src', size: options[:size] ? options[:size] : 4 )
@@ -68,7 +68,7 @@ module Formtastic
 
       def select_dst_html
         selected = options[:selected] ? options[:selected] : object.send( input_name )
-        selected = [selected] if selected.is_a? Fixnum
+        selected = [selected] if selected.is_a? Integer
         coll = selected ? collection.select { |option| selected.include?( option[1] ) } : collection
         opts = input_options.merge( name: nil, id: nil, multiple: true, 'data-select': 'dst', size: options[:size] ? options[:size] : 4 )
         template.select_tag nil, template.options_for_select( coll ), opts


### PR DESCRIPTION
[In Ruby 2.4](https://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html), `Fixnum` and `Bignum` [are deprecated](https://bugs.ruby-lang.org/issues/12739). Because this library uses
`Fixnum`, a deprecation warning is raised when loaded in a Rails app using
Ruby 2.4:

```
warning: constant ::Fixnum is deprecated
```

This commit updates `Fixnum` usage to `Integer` to be compatible with
Ruby 2.4 and beyond. This fix remains backward compatibility with Ruby 
versions prior to 2.4:

```ruby
2.2.2 :001 > 1.is_a?(Fixnum)
 => true
2.2.2 :002 > 1.is_a?(Integer)
 => true
```

---

Thanks for your work on this plugin, @blocknotes!